### PR TITLE
fix typo user.emil

### DIFF
--- a/text/basics/setup.md
+++ b/text/basics/setup.md
@@ -10,7 +10,7 @@ otherwise, so it's worth doing now.)
 
 ```
 $ jj config set --user user.name "My Name"
-$ jj config set --user user.emil "my@email.address"
+$ jj config set --user user.email "my@email.address"
 ```
 
 If you run `jj` with no arguments, it prints a help message that suggests a


### PR DESCRIPTION
thanks for the awesome book, was reading it online and seemed typo at user.emil in below
`$ jj config set --user user.emil "my@email.address" `

also, in official docs it shows as "email"
https://docs.jj-vcs.dev/latest/config/#user-settings

again, appreciate your book :)